### PR TITLE
More fixes

### DIFF
--- a/scripts/bastion-setup/bastion-setup.yaml
+++ b/scripts/bastion-setup/bastion-setup.yaml
@@ -17,7 +17,7 @@
 
     - name: Install needed packages
       ansible.builtin.dnf:
-        name: ["tmux", "vim", "git", "podman", "make", "nginx", "pcp-zeroconf"]
+        name: ["tmux", "vim", "git", "podman", "make", "nginx", "pcp-zeroconf", "words", "sscg", "httpd-tools"]
         state: installed
 
     - name: Create admins

--- a/scripts/lab-setup/README.md
+++ b/scripts/lab-setup/README.md
@@ -29,8 +29,8 @@ Then run:
 
     make install
 
-All the openshift-install files will be in `~/vp-workshop/ocp_install`. One folder per cluster.
-After the installation is complete all files ready for students will be in `~/vp-workshop/student_files/`
+All the openshift-install files will be in `~/vp-workshop-output/ocp_install`. One folder per cluster.
+After the installation is complete all files ready for students will be in `~/vp-workshop-output/student_files/`
 ready to be exported via a scripts in there called `serve.sh`.
 
 

--- a/scripts/lab-setup/roles/deploy-clusters/tasks/main.yml
+++ b/scripts/lab-setup/roles/deploy-clusters/tasks/main.yml
@@ -53,7 +53,7 @@
   register: install_jobs
   until: install_jobs.finished
   delay: 60 # check every minute
-  retries: 90 # 1h and 30mins max wait time
+  retries: 120 # 1h and 30mins max wait time
   loop: "{{ deploy_openshift_clusters.results }}"
 
 - name: Read in ~/.vp_workshop_common_pass

--- a/scripts/lab-setup/roles/deploy-clusters/templates/serve.sh.j2
+++ b/scripts/lab-setup/roles/deploy-clusters/templates/serve.sh.j2
@@ -4,6 +4,7 @@ set -e
 # We use a random simple user/password just to avoid drive-by peeks
 USER=beard
 PASSWORD=$(shuf -n1 /usr/share/dict/words)
+IMAGE=docker.io/library/nginx:latest
 
 # Create self-signed certificates
 # Create self-signed certificates
@@ -28,4 +29,4 @@ podman run -it --rm -p "${PORT}":443 --name nginx \
 	-v "{{ base_dir }}/nginx:/etc/nginx:ro,z" \
 	-v "./ssl/:/etc/nginx/ssl:ro,z" \
 	-v "./ssl/htpasswd:/etc/nginx/.htpasswd:ro,z" \
-	-v "$(pwd)/clusters/:/var/www:ro,z" nginx:latest
+	-v "$(pwd)/clusters/:/var/www:ro,z" "${IMAGE}"

--- a/scripts/lab-setup/vars/defaults.yaml
+++ b/scripts/lab-setup/vars/defaults.yaml
@@ -2,7 +2,7 @@ clusters_count: 1
 aws_region: "eu-west-3"
 ocp_version: "stable-4.11"
 clusters_prefix: "vp-workshop-"
-workshop_output_path: "~/vp-workshop"
+workshop_output_path: "~/vp-workshop-output"
 # Where all the openshift install output files live
 workshop_ocp_install_path: "{{ workshop_output_path }}/ocp_install"
 # Where all the openshift install and ocp client bin files are downloaded


### PR DESCRIPTION
- Switch to ~/vp-workshop-output
- Wait for up to two hours
- Add some more needed rpms
- Us an FQDN container image
