### PR TITLE
Make upgrade conditional in bastion setup

### DIFF
--- a/scripts/bastion-setup/bastion-setup.yaml
+++ b/scripts/bastion-setup/bastion-setup.yaml
@@ -14,6 +14,7 @@
       ansible.builtin.dnf:
         name: "*"
         state: latest
+      when: upgrade_packages
 
     - name: Install needed packages
       ansible.builtin.dnf:

--- a/scripts/bastion-setup/vars/defaults.yaml
+++ b/scripts/bastion-setup/vars/defaults.yaml
@@ -1,4 +1,6 @@
 ---
+upgrade_packages: false
+
 admins:
   ipbabble: https://github.com/ipbabble.keys
   beekhof: https://github.com/beekhof.keys


### PR DESCRIPTION
Currently an open dnf upgrade will fail on c8s because of a dep issue between ansible/ansible-core:

```
[root@bastion bastion-setup]# dnf upgrade
Last metadata expiration check: 0:13:26 ago on Wed 15 Feb 2023 11:36:00 PM CET.
Error: 
 Problem: package ansible-6.3.0-1.el8.noarch requires (python3.9dist(ansible-core) >= 2.13.3 with python3.9dist(ansible-core) < 2.14), but none of the providers can be installed
  - cannot install both ansible-core-2.14.2-2.el8.x86_64 and ansible-core-2.13.5-1.el8.x86_64
  - cannot install both ansible-core-2.14.2-2.el8.x86_64 and ansible-core-2.13.3-1.el8.x86_64
  - cannot install the best update candidate for package ansible-core-2.13.5-1.el8.x86_64
  - cannot install the best update candidate for package ansible-6.3.0-1.el8.noarch
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```